### PR TITLE
Fix package name at AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.zoyi.channel.rn">
 
 </manifest>
   


### PR DESCRIPTION
RN 0.60.5 버전에서 Auto Linking을 사용해서 개발 진행시 계속해서 아래와 같은 에러가 뜨면서 빌드가 되지 않는 현상을 수정했습니다.
```
import com.reactlibrary.RNChannelIOPackage;
                       ^
  symbol:   class RNChannelIOPackage
  location: package com.reactlibrary
/Users/flynn/ABDev/kr_afterbuy_app/android/app/build/generated/rncli/src/main/java/com/facebook/react/PackageList.java:87: error: cannot find symbol
      new RNChannelIOPackage(),
```
