### PR TITLE
enh: 배포 관련 설정 보완

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+rn*example/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,11 +9,11 @@ def computeVersionName() {
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
     }
 
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,13 +23,22 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
+def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_TARGET_SDK_VERSION = 28
+
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion safeExtGet("compileSdkVersion", DEFAULT_COMPILE_SDK_VERSION)
+    buildToolsVersion safeExtGet("buildToolsVersion", DEFAULT_BUILD_TOOLS_VERSION)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+        targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
         versionCode 1
         // get version name from package.json version
         versionName computeVersionName()

--- a/rn60example/package.json
+++ b/rn60example/package.json
@@ -11,7 +11,7 @@
     "@react-native-community/push-notification-ios": "^1.0.2",
     "react": "16.8.6",
     "react-native": "0.60.5",
-    "react-native-channel-plugin": "0.3.5"
+    "react-native-channel-plugin": "^0.3.6"
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",

--- a/rn60example/yarn.lock
+++ b/rn60example/yarn.lock
@@ -825,6 +825,13 @@
     eslint-plugin-react-native "3.6.0"
     prettier "1.16.4"
 
+"@react-native-community/push-notification-ios@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.0.2.tgz#541bc8ce088d726c4a98fff0e261b4d0f555cacf"
+  integrity sha512-9lWaw+zBGvT8Yw9HZmiLkYbnmF5AzrWexYh2qmRt/shpfZawCTPmPBrq09N7JhiPV4g/gEbeLXlndxl1JQeB0g==
+  dependencies:
+    invariant "^2.2.4"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -4502,9 +4509,10 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
 
-react-native-channel-plugin@0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/react-native-channel-plugin/-/react-native-channel-plugin-0.3.5.tgz#1f1e17d307e1c0c0f899d981a7d30c0dadec2fe5"
+react-native-channel-plugin@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/react-native-channel-plugin/-/react-native-channel-plugin-0.3.6.tgz#b6c42ecbd103f35c29518e9c82a870adc7fb5dfd"
+  integrity sha512-P6R5ye17rVphKRuCikD21L1S5dClqEQ6ZrbVCov3lB/f4lCGDwS2Kn+e0MdHsmJR9PVJeUjeSJhMn8uToXVM/Q==
 
 react-native@0.60.5:
   version "0.60.5"


### PR DESCRIPTION
지나가다가 `react-native` 모듈이 있어 잠깐 구경하다가 보완될 부분들이 보여서 소소한 업데이트 넣습니다.
1. `npmignore` 설정이 되지 않아서 `example` project까지 패키징되어 올라가는데 `.npmignore`를 넣어서 수정해주었습니다.
   - 수정 전
      ![image](https://user-images.githubusercontent.com/27461460/66704721-be2cf380-ed59-11e9-9aab-6c07dab94bd8.png)
   - 수정 후
      ![image](https://user-images.githubusercontent.com/27461460/66704727-cedd6980-ed59-11e9-9b1b-484eef7aa56c.png)
> 이는 배포 전 쉽게 `npm pack`으로 테스트 해보시면 됩니다.

2. 과거에 `android` `build.gradle`에서 `jcenter`를 하단에 내려주지 않으면 빌드가 되지 않는 현상이 있어서 내려주었습니다.
   - 레퍼런스: https://ionic.zendesk.com/hc/en-us/articles/360005529314-Android-builds-fail-due-to-missing-jcenter-dependencies

3. `safeExtGet`을 이용하여 `rootProject`의 `sdk` 버전과 충돌이 생기지 않도록 보완했습니다.

